### PR TITLE
Import ExtensionError from primary module.

### DIFF
--- a/sphinxcontrib/googleanalytics.py
+++ b/sphinxcontrib/googleanalytics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from sphinx.application import ExtensionError
+from sphinx.errors import ExtensionError
 
 def add_ga_javascript(app, pagename, templatename, context, doctree):
     if not app.config.googleanalytics_enabled:


### PR DESCRIPTION
Import ExtensionError from primary module.

It is no longer imported into sphinx.application in newer versions.
