### PR TITLE
Updated tag content to match new GA instructions

### DIFF
--- a/sphinxcontrib/googleanalytics.py
+++ b/sphinxcontrib/googleanalytics.py
@@ -3,28 +3,30 @@
 
 from sphinx.errors import ExtensionError
 
+
 def add_ga_javascript(app, pagename, templatename, context, doctree):
     if not app.config.googleanalytics_enabled:
         return
 
     metatags = context.get('metatags', '')
-    metatags += """<script type="text/javascript">
-
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', '%s']);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-    </script>""" % app.config.googleanalytics_id
+    metatags += """
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%s"></script>""" % app.config.googleanalytics_id
+    metatags += """
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '%s');
+    </script>
+    """ % app.config.googleanalytics_id
     context['metatags'] = metatags
+
 
 def check_config(app):
     if not app.config.googleanalytics_id:
         raise ExtensionError("'googleanalytics_id' config value must be set for ga statistics to function properly.")
+
 
 def setup(app):
     app.add_config_value('googleanalytics_id', '', 'html')


### PR DESCRIPTION
The current instructions from the Google Analytics website are to use the following tag:

```
<!-- Google tag (gtag.js) -->
<script async src="https://www.googletagmanager.com/gtag/js?id=GA_ID_HERE"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', 'GA_ID_HERE');
</script>
```

With `GA_ID_HERE` the website ID provided by google analytics.

This amends the current function that adds the tag to each webpage to include this tag instead of the previous tag, which was not working on the website instances I tested it with.