### PR TITLE
Only require googleanalytics_id when googleanalytics_enabled

### DIFF
--- a/sphinxcontrib/googleanalytics.py
+++ b/sphinxcontrib/googleanalytics.py
@@ -24,7 +24,7 @@ def add_ga_javascript(app, pagename, templatename, context, doctree):
 
 
 def check_config(app):
-    if not app.config.googleanalytics_id:
+    if app.config.googleanalytics_enabled and not app.config.googleanalytics_id:
         raise ExtensionError("'googleanalytics_id' config value must be set for ga statistics to function properly.")
 
 


### PR DESCRIPTION
Don't raise an ExtensionError about missing `googleanalytics_id` if `googleanalytics_enabled` is False.

Fixes #14.